### PR TITLE
fix: add browser check for sessionStorage access

### DIFF
--- a/components/TravelTime.tsx
+++ b/components/TravelTime.tsx
@@ -38,7 +38,7 @@ export default function TravelTime({ route }: TravelTimeProps) {
         const cacheKey = `travel-time-${route}-${departureTime}`;
 
         // Only use cache for "now" - always fetch fresh data for selected times
-        if (departureTime === "now") {
+        if (departureTime === "now" && typeof window !== "undefined") {
           const cachedData = sessionStorage.getItem(cacheKey);
           if (cachedData) {
             try {
@@ -75,7 +75,7 @@ export default function TravelTime({ route }: TravelTimeProps) {
         const result = await response.json();
 
         // Only cache "now" results - don't cache user-selected times
-        if (departureTime === "now") {
+        if (departureTime === "now" && typeof window !== "undefined") {
           sessionStorage.setItem(cacheKey, JSON.stringify(result));
         }
 
@@ -98,7 +98,9 @@ export default function TravelTime({ route }: TravelTimeProps) {
       interval = setInterval(() => {
         // Clear cache for "now" before refreshing
         const cacheKey = `travel-time-${route}-now`;
-        sessionStorage.removeItem(cacheKey);
+        if (typeof window !== "undefined") {
+          sessionStorage.removeItem(cacheKey);
+        }
         fetchTravelTime();
       }, 5 * 60 * 1000);
     }


### PR DESCRIPTION
## Problem
The homepage was showing 'Application error: a client-side exception has occurred' due to the TravelTime component accessing `sessionStorage` during server-side rendering.

## Solution
Added `typeof window !== 'undefined'` checks before all `sessionStorage` operations to ensure they only run in browser context.

## Changes
- `components/TravelTime.tsx`: Added browser environment checks for:
  - Cache retrieval (`sessionStorage.getItem`)
  - Cache storage (`sessionStorage.setItem`)
  - Cache clearing in refresh interval (`sessionStorage.removeItem`)