### PR TITLE
feat: add Pavlovica Most routes to Brcko and Novi Sad

### DIFF
--- a/config/routes.ts
+++ b/config/routes.ts
@@ -45,6 +45,18 @@ export const ROUTES: Record<string, RouteConfig> = {
     destination: NOVI_SAD,
     waypoints: ["Gunja, Croatia", "Ilok, Croatia"],
   },
+  "pavlovica-most-brcko": {
+    route: "pavlovica-most-brcko",
+    origin: NOVI_SAD,
+    destination: BRCKO,
+    waypoints: ["Pavlovića most, Serbia"],
+  },
+  "pavlovica-most-novisad": {
+    route: "pavlovica-most-novisad",
+    origin: BRCKO,
+    destination: NOVI_SAD,
+    waypoints: ["Pavlovića most, Serbia"],
+  },
 };
 
 export const getRouteConfig = (route: string): RouteConfig | undefined => {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -88,6 +88,22 @@ export default function Home() {
                     <TravelTime route="backapalanka-ilok-gunja" />
                   </span>
                 </Link>
+
+                <Link
+                  href="/pavlovica-most-brcko"
+                  as="/pavlovica-most-brcko"
+                >
+                  <span className="card">
+                    <h3>
+                      <div className="flag-icons">
+                        <img src="/rs.png" />
+                        <img src="/bih.png" />
+                      </div>
+                    </h3>
+                    <p>Pavlovića most &rarr; Brčko</p>
+                    <TravelTime route="pavlovica-most-brcko" />
+                  </span>
+                </Link>
               </div>
             )}
           </div>
@@ -149,6 +165,22 @@ export default function Home() {
                     </h3>
                     <p>Gunja &rarr; Ilok &rarr; Bačka Palanka</p>
                     <TravelTime route="gunja-ilok-backapalanka" />
+                  </span>
+                </Link>
+
+                <Link
+                  href="/pavlovica-most-novisad"
+                  as="/pavlovica-most-novisad"
+                >
+                  <span className="card">
+                    <h3>
+                      <div className="flag-icons">
+                        <img src="/bih.png" />
+                        <img src="/rs.png" />
+                      </div>
+                    </h3>
+                    <p>Pavlovića most &rarr; Novi Sad</p>
+                    <TravelTime route="pavlovica-most-novisad" />
                   </span>
                 </Link>
               </div>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -100,7 +100,7 @@ export default function Home() {
                         <img src="/bih.png" />
                       </div>
                     </h3>
-                    <p>Pavlovića most &rarr; Brčko</p>
+                    <p>Pavlovića most</p>
                     <TravelTime route="pavlovica-most-brcko" />
                   </span>
                 </Link>
@@ -179,7 +179,7 @@ export default function Home() {
                         <img src="/rs.png" />
                       </div>
                     </h3>
-                    <p>Pavlovića most &rarr; Novi Sad</p>
+                    <p>Pavlovića most</p>
                     <TravelTime route="pavlovica-most-novisad" />
                   </span>
                 </Link>

--- a/pages/pavlovica-most-brcko.tsx
+++ b/pages/pavlovica-most-brcko.tsx
@@ -6,17 +6,17 @@ export default function PavlovicaMostBrcko() {
   const photoStreams = [
     {
       title: "Pavlovića most",
-      desctiption: "izlaz iz Srbije",
+      desctiption: "izlaz iz Bosne",
       direction: "out",
       image: "https://gp.satwork.net/AMSRS_05_GP_PM01/slika.jpg?v=",
-      country: "rs",
+      country: "bih",
     },
     {
       title: "Pavlovića most",
-      desctiption: "ulaz u Bosnu",
+      desctiption: "ulaz u Srbiju",
       direction: "in",
       image: "https://gp.satwork.net/AMSRS_05_GP_PM02/slika.jpg?v=",
-      country: "bih",
+      country: "rs",
     },
   ];
 

--- a/pages/pavlovica-most-brcko.tsx
+++ b/pages/pavlovica-most-brcko.tsx
@@ -1,0 +1,42 @@
+import Layout from "components/Layout/Layout";
+import PhotoItem from "components/Item/PhotoItem";
+import TravelTime from "components/TravelTime";
+
+export default function PavlovicaMostBrcko() {
+  const photoStreams = [
+    {
+      title: "Pavlovića most",
+      desctiption: "izlaz iz Srbije",
+      direction: "out",
+      image: "https://gp.satwork.net/AMSRS_05_GP_PM01/slika.jpg?v=",
+      country: "rs",
+    },
+    {
+      title: "Pavlovića most",
+      desctiption: "ulaz u Bosnu",
+      direction: "in",
+      image: "https://gp.satwork.net/AMSRS_05_GP_PM02/slika.jpg?v=",
+      country: "bih",
+    },
+  ];
+
+  return (
+    <Layout title="Pavlovića most → Brčko">
+      <div className="route-info">
+        <TravelTime route="pavlovica-most-brcko" />
+      </div>
+      <div className="grid-container">
+        {photoStreams.map((item: any) => (
+          <PhotoItem
+            key={item.image}
+            title={item.title}
+            desctiption={item.desctiption}
+            direction={item.direction}
+            image={item.image}
+            country={item.country}
+          />
+        ))}
+      </div>
+    </Layout>
+  );
+}

--- a/pages/pavlovica-most-novisad.tsx
+++ b/pages/pavlovica-most-novisad.tsx
@@ -1,0 +1,42 @@
+import Layout from "components/Layout/Layout";
+import PhotoItem from "components/Item/PhotoItem";
+import TravelTime from "components/TravelTime";
+
+export default function PavlovicaMostNoviSad() {
+  const photoStreams = [
+    {
+      title: "Pavlovića most",
+      desctiption: "izlaz iz Bosne",
+      direction: "out",
+      image: "https://gp.satwork.net/AMSRS_05_GP_PM01/slika.jpg?v=",
+      country: "bih",
+    },
+    {
+      title: "Pavlovića most",
+      desctiption: "ulaz u Srbiju",
+      direction: "in",
+      image: "https://gp.satwork.net/AMSRS_05_GP_PM02/slika.jpg?v=",
+      country: "rs",
+    },
+  ];
+
+  return (
+    <Layout title="Pavlovića most → Novi Sad">
+      <div className="route-info">
+        <TravelTime route="pavlovica-most-novisad" />
+      </div>
+      <div className="grid-container">
+        {photoStreams.map((item: any) => (
+          <PhotoItem
+            key={item.image}
+            title={item.title}
+            desctiption={item.desctiption}
+            direction={item.direction}
+            image={item.image}
+            country={item.country}
+          />
+        ))}
+      </div>
+    </Layout>
+  );
+}

--- a/pages/pavlovica-most-novisad.tsx
+++ b/pages/pavlovica-most-novisad.tsx
@@ -6,17 +6,17 @@ export default function PavlovicaMostNoviSad() {
   const photoStreams = [
     {
       title: "Pavlovića most",
-      desctiption: "izlaz iz Bosne",
+      desctiption: "izlaz iz Srbije",
       direction: "out",
-      image: "https://gp.satwork.net/AMSRS_05_GP_PM01/slika.jpg?v=",
-      country: "bih",
+      image: "https://gp.satwork.net/AMSRS_05_GP_PM02/slika.jpg?v=",
+      country: "rs",
     },
     {
       title: "Pavlovića most",
-      desctiption: "ulaz u Srbiju",
+      desctiption: "ulaz u Bosnu",
       direction: "in",
-      image: "https://gp.satwork.net/AMSRS_05_GP_PM02/slika.jpg?v=",
-      country: "rs",
+      image: "https://gp.satwork.net/AMSRS_05_GP_PM01/slika.jpg?v=",
+      country: "bih",
     },
   ];
 


### PR DESCRIPTION
## Changes
Added Pavlovića most border crossing routes to the homepage.

### New Routes
- **Pavlovića most → Brčko** (in the → BRČKO section)
- **Pavlovića most → Novi Sad** (in the → NOVI SAD section)

### Files Added/Modified
- `pages/pavlovica-most-brcko.tsx` - new route page with camera feeds
- `pages/pavlovica-most-novisad.tsx` - new route page with camera feeds  
- `config/routes.ts` - added route configs for travel time
- `pages/index.tsx` - added cards to both direction sections

### Camera Sources
Using existing Pavlovića most cameras from satwork.net (same as in /bosna page)